### PR TITLE
Update IP to be version 2.0.1 to patch vulnerability CVE-2023-42282

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "express": "~4.16.1",
         "express-mysql-session": "^2.1.8",
         "express-session": "^1.17.3",
+        "ip": "^2.0.1",
         "morgan": "~1.9.1",
         "neo4j-driver": "^5.3.0",
         "newrelic": "^7.3.1",
@@ -4490,6 +4491,11 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
       "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
       "dev": true
+    },
+    "node_modules/ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -11389,6 +11395,11 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
       "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
       "dev": true
+    },
+    "ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
     },
     "ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "express": "~4.16.1",
     "express-mysql-session": "^2.1.8",
     "express-session": "^1.17.3",
+    "ip": "^2.0.1",
     "morgan": "~1.9.1",
     "neo4j-driver": "^5.3.0",
     "newrelic": "^7.3.1",


### PR DESCRIPTION
Update IP to be version 2.0.1 to patch vulnerability CVE-2023-42282

Proposed fix
 Upgrade your installed software packages to the proposed fixed in version and release.

Description: The ip package before 1.1.9 for Node.js might allow SSRF because some IP addresses (such as 0x7f.1) are improperly categorized as globally routable via isPublic.