### PR TITLE
Initialize git submodules in CI build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,8 @@ jobs:
 
     - name: Check out code
       uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
+      with:
+        submodules: recursive
 
     - name: Set Image Tag
       env:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The change ensures that all git submodules are checked out when the workflow runs.